### PR TITLE
use document.documentElement.scrollTop

### DIFF
--- a/code.js
+++ b/code.js
@@ -1,6 +1,8 @@
-function scroll(){
+function scroll() {
   var h = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
-  if(document.body.scrollTop+h+1000 > document.body.scrollHeight){
+  var scrollTop = document.body.scrollTop || document.documentElement.scrollTop;
+
+  if (scrollTop + h + 1000 > document.body.scrollHeight) {
     document.body.style.height = document.body.scrollHeight + 500 + "px";
   }
 }


### PR DESCRIPTION
currently website doesn't work for me with chrome 58.0 or firefox 53.0.2 on win10. `document.body.scrollTop` is always 0, so the infinite scroll breaks. 

per [this stackoverflow post](https://stackoverflow.com/questions/28633221/document-body-scrolltop-firefox-returns-0-only-js), `document.body.scrollTop` is deprecated in favor of `document.documentElement.scrollTop`, and using this fixes the problem for me. i've just ORed the two together, so this shouldn't break the site for anyone else either.